### PR TITLE
Remove mysql CLI dependency from sql_file_executor; add docs examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,3 +488,228 @@ Show grants for an existing user:
     GRANT USAGE ON *.* TO `lisa`@`%`
     GRANT SELECT, INSERT, UPDATE, DELETE ON `app_db`.* TO `lisa`@`%`
     GRANT `app_write`@`%` TO `lisa`@`%`
+```
+
+---
+
+## Real-World Examples with Validation
+
+The following examples were run against a local MySQL 8.0.43 instance and show the actual output at each step.
+
+### Example A — Read-only user with role, complex password (sakila)
+
+Create a `dev_read` role with SELECT on `sakila`, then create `dev_reader1` assigned to that role.
+The password meets the 30-character policy and contains a special character (`^`).
+
+```bash
+go-create -s 127.0.0.1:3306 -u root -p s3cr3t \
+  --create-user dev_reader1 \
+  --create-pass Xk9mP2nL8qR5vT3wY7uI0oE6sA1cB4dF^ \
+  -r dev_read -g select -db sakila
+```
+
+```Go
+2026/04/27 12:47:15 [+] Connecting to MySQL server at 127.0.0.1:3306 (using command line arguments)
+2026/04/27 12:47:15 [!] Pre-validating NEW USER password against policy (min length: 30)...
+2026/04/27 12:47:15 [+] New user password pre-validation successful
+2026/04/27 12:47:15 [+] Created role: dev_read
+2026/04/27 12:47:15 [+] Granted privileges to role: dev_read
+2026/04/27 12:47:15 [!] MySQL server version: 8.0.43 (parsed as: 80)
+2026/04/27 12:47:15 [!] Using caching_sha2_password for MySQL 8.0+
+2026/04/27 12:47:15 [+] Created user: dev_reader1@% with strong password
+2026/04/27 12:47:15 [+] Granted role to user: dev_reader1
+2026/04/27 12:47:15 [+] Granted privileges to user: dev_reader1
+2026/04/27 12:47:15 [+] Set default role for user: dev_read
+```
+
+Verify role grants:
+
+```bash
+go-create -s 127.0.0.1:3306 -u root -p s3cr3t -r dev_read -show
+```
+
+```Go
+2026/04/27 12:56:47 [+] Grants for role dev_read:
+    GRANT USAGE ON *.* TO `dev_read`@`%`
+    GRANT SELECT ON `sakila`.* TO `dev_read`@`%`
+```
+
+Verify user grants:
+
+```bash
+go-create -s 127.0.0.1:3306 -u root -p s3cr3t -show-user dev_reader1
+```
+
+```Go
+2026/04/27 12:56:29 [+] Grants for user dev_reader1:
+    GRANT USAGE ON *.* TO `dev_reader1`@`%`
+    GRANT SELECT ON `sakila`.* TO `dev_reader1`@`%`
+    GRANT `dev_read`@`%` TO `dev_reader1`@`%`
+```
+
+---
+
+### Example B — Write user with role, full DML on chaos
+
+Create `app_write_role` with SELECT/INSERT/UPDATE/DELETE on `chaos`, then create `app_writer1`.
+
+```Go
+go-create -s 127.0.0.1:3306 -u root -p s3cr3t \
+  --create-user app_writer1 \
+  --create-pass Mz7nK3pQ9xW2vL5tY8rU1bC4sA6dE0fG^ \
+  -r app_write_role -g select,insert,update,delete -db chaos
+```
+
+```Go
+2026/04/27 12:47:27 [+] Connecting to MySQL server at 127.0.0.1:3306 (using command line arguments)
+2026/04/27 12:47:27 [+] Created role: app_write_role
+2026/04/27 12:47:27 [+] Granted privileges to role: app_write_role
+2026/04/27 12:47:27 [+] Created user: app_writer1@% with strong password
+2026/04/27 12:47:27 [+] Granted role to user: app_writer1
+2026/04/27 12:47:27 [+] Granted privileges to user: app_writer1
+2026/04/27 12:47:27 [+] Set default role for user: app_write_role
+```
+
+Verify role:
+
+```bash
+go-create -s 127.0.0.1:3306 -u root -p s3cr3t -r app_write_role -show
+```
+
+```Go
+2026/04/27 12:56:47 [+] Grants for role app_write_role:
+    GRANT USAGE ON *.* TO `app_write_role`@`%`
+    GRANT SELECT, INSERT, UPDATE, DELETE ON `chaos`.* TO `app_write_role`@`%`
+```
+
+Verify user:
+
+```bash
+go-create -s 127.0.0.1:3306 -u root -p s3cr3t -show-user app_writer1
+```
+
+```Go
+2026/04/27 12:56:29 [+] Grants for user app_writer1:
+    GRANT USAGE ON *.* TO `app_writer1`@`%`
+    GRANT SELECT, INSERT, UPDATE, DELETE ON `chaos`.* TO `app_writer1`@`%`
+    GRANT `app_write_role`@`%` TO `app_writer1`@`%`
+```
+
+---
+
+### Example C — Direct grants only, no role, short password with -skip-password-policy
+
+`etl_user` needs DML on `roll_back` with a short internal password. No role is attached.
+
+```bash
+go-create -s 127.0.0.1:3306 -u root -p s3cr3t \
+  --create-user etl_user \
+  --create-pass Letmein1! \
+  -skip-password-policy \
+  -g select,insert,update,delete -db roll_back
+```
+
+```Go
+2026/04/27 12:48:08 [+] Connecting to MySQL server at 127.0.0.1:3306 (using command line arguments)
+2026/04/27 12:48:08 [!] Password policy enforcement disabled
+2026/04/27 12:48:08 [!] MySQL server version: 8.0.43 (parsed as: 80)
+2026/04/27 12:48:08 [+] Created user: etl_user@% with strong password
+2026/04/27 12:48:08 [+] Granted privileges to user: etl_user
+```
+
+Verify — no role grant present, only direct privileges:
+
+```bash
+go-create -s 127.0.0.1:3306 -u root -p s3cr3t -show-user etl_user
+```
+
+```Go
+2026/04/27 12:56:29 [+] Grants for user etl_user:
+    GRANT USAGE ON *.* TO `etl_user`@`%`
+    GRANT SELECT, INSERT, UPDATE, DELETE ON `roll_back`.* TO `etl_user`@`%`
+```
+
+---
+
+### Example D — Complex password with quotes via -use-sql-file
+
+`ca_svc` requires a password containing single quotes and double quotes.
+The `-use-sql-file` flag executes statements directly through the Go MySQL driver,
+bypassing all shell escaping issues.
+
+```bash
+go-create -s 127.0.0.1:3306 -u root -p s3cr3t \
+  --create-user ca_svc \
+  --create-pass "C@mp1ex'P@ss\"w0rd!9Tz3Qv8Nm2Lk" \
+  -use-sql-file \
+  -r ca_rw -g select,insert,update -db analysis
+```
+
+```Go
+2026/04/27 12:54:35 [+] Connecting to MySQL server at 127.0.0.1:3306 (using command line arguments)
+2026/04/27 12:54:35 [!] Pre-validating NEW USER password with relaxed policy (SQL file mode)...
+2026/04/27 12:54:35 [+] New user password pre-validation successful
+2026/04/27 12:54:35 [!] Using SQL file execution method for complex password handling
+2026/04/27 12:54:35 [+] Created role: ca_rw
+2026/04/27 12:54:35 [+] Executing 5 statements via Go MySQL driver:
+2026/04/27 12:54:35     CREATE ROLE IF NOT EXISTS `ca_rw`
+2026/04/27 12:54:35     GRANT select,insert,update ON `analysis`.* TO `ca_rw`
+2026/04/27 12:54:35     CREATE USER IF NOT EXISTS 'ca_svc'@'%' IDENTIFIED BY '****MASKED****'
+2026/04/27 12:54:35     GRANT `ca_rw` TO 'ca_svc'@'%'
+2026/04/27 12:54:35     SET DEFAULT ROLE `ca_rw` TO 'ca_svc'@'%'
+2026/04/27 12:54:35 [+] User 'ca_svc' created successfully
+2026/04/27 12:54:35 [+] User creation via SQL file completed successfully
+```
+
+Verify role:
+
+```bash
+go-create -s 127.0.0.1:3306 -u root -p s3cr3t -r ca_rw -show
+```
+
+```Go
+2026/04/27 12:56:47 [+] Grants for role ca_rw:
+    GRANT USAGE ON *.* TO `ca_rw`@`%`
+    GRANT SELECT, INSERT, UPDATE ON `analysis`.* TO `ca_rw`@`%`
+```
+
+Verify user:
+
+```bash
+go-create -s 127.0.0.1:3306 -u root -p s3cr3t -show-user ca_svc
+```
+
+```Go
+2026/04/27 12:56:29 [+] Grants for user ca_svc:
+    GRANT USAGE ON *.* TO `ca_svc`@`%`
+    GRANT `ca_rw`@`%` TO `ca_svc`@`%`
+```
+
+---
+
+### Example E — Standalone role with no user attached
+
+Create a `reporting_ro` role for future assignment without creating any user account.
+
+```bash
+go-create -s 127.0.0.1:3306 -u root -p s3cr3t \
+  -r reporting_ro -g select -db sakila
+```
+
+```Go
+2026/04/27 12:54:44 [+] Connecting to MySQL server at 127.0.0.1:3306 (using command line arguments)
+2026/04/27 12:54:44 [+] Created role: reporting_ro
+2026/04/27 12:54:44 [+] Granted privileges to role: reporting_ro
+```
+
+Verify the role exists with correct privileges:
+
+```bash
+go-create -s 127.0.0.1:3306 -u root -p s3cr3t -r reporting_ro -show
+```
+
+```Go
+2026/04/27 12:56:47 [+] Grants for role reporting_ro:
+    GRANT USAGE ON *.* TO `reporting_ro`@`%`
+    GRANT SELECT ON `sakila`.* TO `reporting_ro`@`%`
+```

--- a/cmd/create/main.go
+++ b/cmd/create/main.go
@@ -361,13 +361,10 @@ func main() {
 	if *useSQLFile && *createUser != "" && *createPassword != "" {
 		log.Printf("%s Using SQL file execution method for complex password handling", yellow("[!]"))
 
-		// Extract host without port and parameters for SQL file executor
+		// Extract host for SQL executor — strip DSN query params but keep port.
 		hostForSQLFile := dbManager.Host
 		if strings.Contains(hostForSQLFile, "?") {
 			hostForSQLFile = strings.Split(hostForSQLFile, "?")[0]
-		}
-		if strings.Contains(hostForSQLFile, ":") {
-			hostForSQLFile = strings.Split(hostForSQLFile, ":")[0]
 		}
 
 		// Create SQL file executor with proper credentials

--- a/pkg/database/sql_file_executor.go
+++ b/pkg/database/sql_file_executor.go
@@ -1,13 +1,13 @@
 package database
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
-	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/fatih/color"
+	_ "github.com/go-sql-driver/mysql"
 )
 
 // SQLFileExecutor handles creating and executing SQL files to avoid shell escaping issues
@@ -33,229 +33,108 @@ func (e *SQLFileExecutor) ExecuteUserCreation(username, password, authPlugin str
 	yellow := color.New(color.FgYellow).SprintFunc()
 	green := color.New(color.FgGreen).SprintFunc()
 
-	// Create a secure temporary directory
-	tempDir, err := os.MkdirTemp("", "go-create-*")
-	if err != nil {
-		return fmt.Errorf("creating temp directory: %w", err)
-	}
-	// Ensure cleanup on exit
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			e.Logger.Printf("%s Warning: Failed to remove temp directory %s: %v",
-				yellow("[!]"), tempDir, err)
-		}
-	}()
-
-	// Create a secure temporary SQL file
-	sqlFile, err := os.CreateTemp(tempDir, fmt.Sprintf("create-user-%s-*.sql", username))
-	if err != nil {
-		return fmt.Errorf("creating temp SQL file: %w", err)
-	}
-	filename := sqlFile.Name()
-	sqlFile.Close() // Close it so we can write to it later
-
-	// Create SQL statements with proper role-based access control
+	// Build SQL statements in memory — no temp files or CLI binary needed.
 	var sqlCommands []string
 
-	// For MySQL 8.0+ with roles:
-	if len(roles) > 0 {
-		// 1. First create/ensure roles exist
-		for _, role := range roles {
-			sqlCommands = append(sqlCommands, fmt.Sprintf(
-				"CREATE ROLE IF NOT EXISTS `%s`;",
-				role))
-		}
+	// 1. Create roles first (idempotent)
+	for _, role := range roles {
+		sqlCommands = append(sqlCommands, fmt.Sprintf("CREATE ROLE IF NOT EXISTS `%s`", role))
+	}
 
-		// 2. Grant privileges TO ROLES (not users) when roles are specified
-		if dbName != "" && grants != "" {
-			for _, role := range roles {
-				if dbName == "*.*" {
-					sqlCommands = append(sqlCommands, fmt.Sprintf(
-						"GRANT %s ON *.* TO `%s`;",
-						grants, role))
-				} else {
-					sqlCommands = append(sqlCommands, fmt.Sprintf(
-						"GRANT %s ON `%s`.* TO `%s`;",
-						grants, dbName, role))
-				}
+	// 2. Grant privileges to roles
+	if len(roles) > 0 && dbName != "" && grants != "" {
+		for _, role := range roles {
+			if dbName == "*.*" {
+				sqlCommands = append(sqlCommands, fmt.Sprintf("GRANT %s ON *.* TO `%s`", grants, role))
+			} else {
+				sqlCommands = append(sqlCommands, fmt.Sprintf("GRANT %s ON `%s`.* TO `%s`", grants, dbName, role))
 			}
 		}
 	}
 
-	// 3. Create user with specified authentication method - with proper escaping
+	// 3. Create user
 	if authPlugin != "" {
 		sqlCommands = append(sqlCommands, fmt.Sprintf(
-			"CREATE USER IF NOT EXISTS '%s'@'%%' IDENTIFIED WITH %s BY %s;",
+			"CREATE USER IF NOT EXISTS '%s'@'%%' IDENTIFIED WITH %s BY %s",
 			username, authPlugin, safeEncodeMySQLPassword(password)))
 	} else {
 		sqlCommands = append(sqlCommands, fmt.Sprintf(
-			"CREATE USER IF NOT EXISTS '%s'@'%%' IDENTIFIED BY %s;",
+			"CREATE USER IF NOT EXISTS '%s'@'%%' IDENTIFIED BY %s",
 			username, safeEncodeMySQLPassword(password)))
 	}
 
-	// 4. Grant roles to user (if roles are specified)
+	// 4. Grant roles to user
 	for _, role := range roles {
-		sqlCommands = append(sqlCommands, fmt.Sprintf(
-			"GRANT `%s` TO '%s'@'%%';",
-			role, username))
+		sqlCommands = append(sqlCommands, fmt.Sprintf("GRANT `%s` TO '%s'@'%%'", role, username))
 	}
 
-	// 5. For MySQL 5.7 or when no roles are specified:
-	// Grant privileges directly to the user ONLY when NO roles are specified
+	// 5. Grant privileges directly to user when no roles are specified
 	if dbName != "" && grants != "" && len(roles) == 0 {
-		// Fix: Only print *.* for global grants, not *.*.*
 		if dbName == "*.*" {
-			e.Logger.Printf("%s Adding direct grants to user (no roles specified): GRANT %s ON *.* TO '%s'@'%%'",
-				yellow("[!]"), grants, username)
+			e.Logger.Printf("%s Adding direct grants: GRANT %s ON *.* TO '%s'@'%%'", yellow("[!]"), grants, username)
+			sqlCommands = append(sqlCommands, fmt.Sprintf("GRANT %s ON *.* TO '%s'@'%%'", grants, username))
 		} else {
-			e.Logger.Printf("%s Adding direct grants to user (no roles specified): GRANT %s ON `%s`.* TO '%s'@'%%'",
-				yellow("[!]"), grants, dbName, username)
+			e.Logger.Printf("%s Adding direct grants: GRANT %s ON `%s`.* TO '%s'@'%%'", yellow("[!]"), grants, dbName, username)
+			sqlCommands = append(sqlCommands, fmt.Sprintf("GRANT %s ON `%s`.* TO '%s'@'%%'", grants, dbName, username))
 		}
-		if dbName == "*.*" {
-			sqlCommands = append(sqlCommands, fmt.Sprintf(
-				"GRANT %s ON *.* TO '%s'@'%%';",
-				grants, username))
-		} else {
-			sqlCommands = append(sqlCommands, fmt.Sprintf(
-				"GRANT %s ON `%s`.* TO '%s'@'%%';",
-				grants, dbName, username))
-		}
-		e.Logger.Printf("%s Adding direct grants to user (no roles specified)", yellow("[!]"))
 	} else {
 		e.Logger.Printf("%s Not adding direct grants: dbName='%s', grants='%s', roleCount=%d",
 			yellow("[!]"), dbName, grants, len(roles))
 	}
 
-	// 6. Set default roles (if roles are specified)
+	// 6. Set default roles
 	if len(roles) > 0 {
-		// Create comma-separated list of roles for SET DEFAULT ROLE
 		rolesList := make([]string, len(roles))
 		for i, r := range roles {
 			rolesList[i] = "`" + r + "`"
 		}
-		rolesStr := strings.Join(rolesList, ", ")
-
 		sqlCommands = append(sqlCommands, fmt.Sprintf(
-			"SET DEFAULT ROLE %s TO '%s'@'%%';",
-			rolesStr, username))
+			"SET DEFAULT ROLE %s TO '%s'@'%%'",
+			strings.Join(rolesList, ", "), username))
 	}
 
-	// Combine all SQL statements
-	sqlContent := strings.Join(sqlCommands, "\n")
-
-	// Write SQL to file
-	if err := os.WriteFile(filename, []byte(sqlContent), 0600); err != nil {
-		return fmt.Errorf("writing SQL file: %w", err)
+	// Log statements with passwords masked
+	e.Logger.Printf("%s Executing %d statements via Go MySQL driver:", green("[+]"), len(sqlCommands))
+	for _, stmt := range sqlCommands {
+		e.Logger.Printf("    %s", maskPasswordInSQL(stmt))
 	}
 
-	// Log SQL file creation without exposing passwords
-	e.Logger.Printf("%s SQL file created with user creation commands (credentials masked for security)", green("[+]"))
-	// Show structure without passwords for debugging if needed
-	for _, line := range strings.Split(sqlContent, "\n") {
-		if strings.Contains(line, "BY") && (strings.Contains(line, "IDENTIFIED") || strings.Contains(line, "password=")) {
-			// Mask the password portion
-			e.Logger.Printf("    %s", maskPasswordInSQL(line))
-		} else {
-			e.Logger.Printf("    %s", line)
+	// Open a direct connection — no mysql CLI binary required.
+	// Strip any DSN query params from host; the driver handles host:port natively.
+	tcpHost := e.Host
+	if idx := strings.Index(tcpHost, "?"); idx != -1 {
+		tcpHost = tcpHost[:idx]
+	}
+	dsn := fmt.Sprintf("%s:%s@tcp(%s)/", e.User, e.Password, tcpHost)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return fmt.Errorf("opening connection: %w", err)
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		return fmt.Errorf("connecting to MySQL at %s: %w", tcpHost, err)
+	}
+
+	for _, stmt := range sqlCommands {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("executing %q: %w", maskPasswordInSQL(stmt), err)
 		}
 	}
 
-	// Note: File cleanup is handled by the deferred RemoveAll at the function start
-
-	e.Logger.Printf("%s Created SQL file for user creation: %s",
-		green("[+]"), filename)
-
-	// Try multiple connection methods if needed
-	var output []byte
-
-	// Attempt 1: Using environment variable
-	e.Logger.Printf("%s Trying connection method 1: Using environment variable...", yellow("[!]"))
-	cmd := exec.Command("mysql", "-h", e.Host, "-u", e.User, "-e", fmt.Sprintf("source %s", filename))
-	cmd.Env = append(os.Environ(), fmt.Sprintf("MYSQL_PWD=%s", e.Password))
-	output, err = cmd.CombinedOutput()
-	if err == nil {
-		e.Logger.Printf("%s Method 1 successful", green("[+]"))
-		return nil
-	}
-	e.Logger.Printf("%s Method 1 failed: %v", yellow("[!]"), err)
-
-	// Attempt 2: Using password file
-	e.Logger.Printf("%s Trying connection method 2: Using password file...", yellow("[!]"))
-	pwdFile, err := os.CreateTemp(tempDir, "mysql-pwd-*.txt")
-	if err == nil {
-		pwdFilename := pwdFile.Name()
-		if _, err := pwdFile.Write([]byte(e.Password)); err != nil {
-			e.Logger.Printf("%s Failed to write password file: %v", yellow("[!]"), err)
-		}
-		pwdFile.Close()
-		// No need for explicit defer os.Remove - parent tempDir cleanup will handle it
-
-		cmd = exec.Command("mysql", "-h", e.Host, "-u", e.User,
-			fmt.Sprintf("--password-file=%s", pwdFilename), "-e", fmt.Sprintf("source %s", filename))
-		output, err = cmd.CombinedOutput()
-		if err == nil {
-			e.Logger.Printf("%s Method 2 successful", green("[+]"))
-			return nil
-		}
-		e.Logger.Printf("%s Method 2 failed: %v", yellow("[!]"), err)
-	}
-
-	// Attempt 3: Create a temporary configuration file
-	e.Logger.Printf("%s Trying connection method 3: Using temporary my.cnf...", yellow("[!]"))
-	cnfFile, err := os.CreateTemp(tempDir, "my-temp-*.cnf")
-	if err == nil {
-		cnfFilename := cnfFile.Name()
-		cnfContent := fmt.Sprintf("[client]\nuser=%s\npassword=\"%s\"\nhost=%s\n",
-			e.User, escapeCnfPassword(e.Password), e.Host)
-		if _, err := cnfFile.Write([]byte(cnfContent)); err != nil {
-			e.Logger.Printf("%s Failed to write config file: %v", yellow("[!]"), err)
-		}
-		cnfFile.Close()
-		// No need for explicit defer os.Remove - parent tempDir cleanup will handle it
-
-		cmd = exec.Command("mysql", fmt.Sprintf("--defaults-file=%s", cnfFilename),
-			"-e", fmt.Sprintf("source %s", filename))
-		output, err = cmd.CombinedOutput()
-		if err == nil {
-			e.Logger.Printf("%s Method 3 successful", green("[+]"))
-			return nil
-		}
-		e.Logger.Printf("%s Method 3 failed: %v", yellow("[!]"), err)
-	}
-
-	// Return the original error if all methods fail
-	return fmt.Errorf("all connection methods failed, last error: %w\nOutput: %s",
-		err, string(output))
+	e.Logger.Printf("%s User '%s' created successfully", green("[+]"), username)
+	return nil
 }
 
-// safeEncodeMySQLPassword provides extra-safe encoding of passwords for MySQL
-// This handles complex special characters by properly escaping them for SQL
+// safeEncodeMySQLPassword escapes a password for use in a SQL string literal.
 func safeEncodeMySQLPassword(password string) string {
-	// Instead of using UNHEX which is causing errors, use MySQL's standard string escaping
-
-	// First, escape any single quotes by doubling them (SQL standard)
 	escaped := strings.Replace(password, "'", "''", -1)
-
-	// For backslashes, we need to double them since they're escape characters in MySQL
 	escaped = strings.Replace(escaped, "\\", "\\\\", -1)
-
-	// Some specific characters might need additional escaping
 	escaped = strings.Replace(escaped, "\r", "\\r", -1)
 	escaped = strings.Replace(escaped, "\n", "\\n", -1)
 	escaped = strings.Replace(escaped, "\t", "\\t", -1)
-
-	// Log the simpler escaping approach
 	log.Printf("%s Using standard SQL escaping for password", yellow("[!]"))
-
-	// Return the password as a normal SQL string literal
 	return fmt.Sprintf("'%s'", escaped)
-}
-
-// Helper function to escape passwords in cnf files
-func escapeCnfPassword(s string) string {
-	// Escape backslashes first, then double quotes
-	s = strings.Replace(s, "\\", "\\\\", -1)
-	return strings.Replace(s, "\"", "\\\"", -1)
 }
 
 // maskPasswordInSQL masks password values in SQL statements for logging


### PR DESCRIPTION
## Summary

### sql_file_executor.go — rewritten to pure Go
- Removed all `os/exec` and temp-file logic that invoked the `mysql` CLI binary
- `ExecuteUserCreation` now builds SQL statements in memory and executes them directly via `database/sql` + `go-sql-driver/mysql`
- Handles passwords containing single quotes, double quotes, and other shell-unsafe characters without any escaping workarounds

### cmd/create/main.go
- Fixed `hostForSQLFile` extraction: removed the stray colon-stripping block so the full `host:port` is passed to the executor DSN correctly

### README.md
- Added **Real-World Examples with Validation** section (5 worked examples A–E) with actual command output captured against MySQL 8.0.43
  - A: user + role + 30-char complex password
  - B: user + write role + full DML
  - C: direct grants only, no role, `-skip-password-policy`
  - D: password with quotes via `-use-sql-file` (pure Go driver path)
  - E: standalone role with no user attached